### PR TITLE
Fix missing wildcards in BDROM constructor file search

### DIFF
--- a/src/BDInfo/BDROM.cs
+++ b/src/BDInfo/BDROM.cs
@@ -146,7 +146,7 @@ namespace BDInfo
             }
 
             if (DirectorySNP != null &&
-                (DirectorySNP.GetFiles(".mnv").Length > 0 || DirectorySNP.GetFiles(".MNV").Length > 0))
+                (DirectorySNP.GetFiles("*.mnv").Length > 0 || DirectorySNP.GetFiles("*.MNV").Length > 0))
             {
                 IsPSP = true;
             }
@@ -177,10 +177,10 @@ namespace BDInfo
 
             if (DirectoryPLAYLIST != null)
             {
-                IFileInfo[] files = DirectoryPLAYLIST.GetFiles(".mpls");
+                IFileInfo[] files = DirectoryPLAYLIST.GetFiles("*.mpls");
                 if (files.Length == 0)
                 {
-                    files = DirectoryPLAYLIST.GetFiles(".MPLS");
+                    files = DirectoryPLAYLIST.GetFiles("*.MPLS");
                 }
                 foreach (IFileInfo file in files)
                 {
@@ -191,10 +191,10 @@ namespace BDInfo
 
             if (DirectorySTREAM != null)
             {
-                IFileInfo[] files = DirectorySTREAM.GetFiles(".m2ts");
+                IFileInfo[] files = DirectorySTREAM.GetFiles("*.m2ts");
                 if (files.Length == 0)
                 {
-                    files = DirectoryPLAYLIST.GetFiles(".M2TS");
+                    files = DirectoryPLAYLIST.GetFiles("*.M2TS");
                 }
                 foreach (IFileInfo file in files)
                 {
@@ -205,10 +205,10 @@ namespace BDInfo
 
             if (DirectoryCLIPINF != null)
             {
-                IFileInfo[] files = DirectoryCLIPINF.GetFiles(".clpi");
+                IFileInfo[] files = DirectoryCLIPINF.GetFiles("*.clpi");
                 if (files.Length == 0)
                 {
-                    files = DirectoryPLAYLIST.GetFiles(".CLPI");
+                    files = DirectoryPLAYLIST.GetFiles("*.CLPI");
                 }
                 foreach (IFileInfo file in files)
                 {
@@ -219,10 +219,10 @@ namespace BDInfo
 
             if (DirectorySSIF != null)
             {
-                IFileInfo[] files = DirectorySSIF.GetFiles(".ssif");
+                IFileInfo[] files = DirectorySSIF.GetFiles("*.ssif");
                 if (files.Length == 0)
                 {
-                    files = DirectorySSIF.GetFiles(".SSIF");
+                    files = DirectorySSIF.GetFiles("*.SSIF");
                 }
                 foreach (IFileInfo file in files)
                 {


### PR DESCRIPTION
Bug Description:
The BDROM constructor fails to load .mpls, .m2ts, and .clpi files because the wildcard * is missing in the GetFiles() method calls (e.g., searching for ".mpls" instead of "*.mpls").

Because it searches for files with the exact name ".mpls", it finds nothing. This leaves the internal dictionaries (PlaylistFiles, StreamClipFiles, StreamFiles) completely empty, which causes the Scan() method to silently skip all loops and return empty results.

Fix:
Added the missing * wildcards to the respective GetFiles() calls in BDROM.cs to correctly match the file extensions and populate the dictionaries.